### PR TITLE
Symfony 4 support

### DIFF
--- a/Process/Step/LegacyAbstractControllerStep.php
+++ b/Process/Step/LegacyAbstractControllerStep.php
@@ -12,15 +12,18 @@
 namespace Sylius\Bundle\FlowBundle\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+@trigger_error(sprintf('The "%s" class is deprecated', LegacyAbstractControllerStep::class), E_USER_DEPRECATED);
 
 /**
- * Step class which extends the base Symfony abstract controller.
+ * @deprecated use the {@see AbstractControllerStep} instead
+ *
+ * Step class which extends the base Symfony2 controller.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
- * @author MiWay Developers <developers@miway.co.za>
  */
-abstract class AbstractControllerStep extends AbstractController implements StepInterface
+abstract class LegacyAbstractControllerStep extends Controller implements StepInterface
 {
     /**
      * Step name in current scenario.

--- a/Process/Step/LegacyAbstractControllerStep.php
+++ b/Process/Step/LegacyAbstractControllerStep.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
  *
  * Step class which extends the base Symfony2 controller.
  *
- * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author MiWay Developers <developers@miway.co.za>
  */
 abstract class LegacyAbstractControllerStep extends Controller implements StepInterface
 {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^3.0 || ^4.0"
+        "symfony/framework-bundle": "^3.3 || ^4.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.0",


### PR DESCRIPTION
* Extend AbstractControllerStep from Symfony's base AbstractController (for dependency injection best practises)
* Created LegacyAbstractControllerStep for backwards compatibility
* Limit Symfony framework bundle min version to 3.3